### PR TITLE
revert readme server port to 7082

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run both the server and client, you can run the following command:
 npm run dev
 ```
 
-This will run the server on port 5000 (defaulted by debug mode) and the client on 7081
+This will run the server on port 7082 and the client on 7081
 
 ## Tests
 


### PR DESCRIPTION
The debug does not default the port to 5000, that must have been something else. After pull the master, the server started to 7082 again (works on 7082 for everyone)