### PR TITLE
add post and comment routes for single user

### DIFF
--- a/post_service/controllers/post_controller.py
+++ b/post_service/controllers/post_controller.py
@@ -222,3 +222,16 @@ class PostSearch(Resource):
                 result_posts.append(post)
 
         return result_posts
+
+
+@ns.route('/posts/<string:user_uuid>')
+class UserPosts(Resource):
+    @ns.marshal_list_with(post_dto, envelope='posts')
+    def get(self, category, user_uuid):
+        result_posts = Post.query.filter_by(author_uuid=user_uuid) \
+                            .order_by(desc(Post.pub_date)).all()
+
+        for post in result_posts:
+            nest_author_info(post)
+
+        return result_posts

--- a/server/controllers/server_controller.py
+++ b/server/controllers/server_controller.py
@@ -82,6 +82,13 @@ class PostSearch(Resource):
         return requests.get('http://post_service:7082/api/' + category + '/search/' + search).json()
 
 
+@ns.route('/<string:category>/posts/<string:user_uuid>')
+class UserPosts(Resource):
+    def get(self, category, user_uuid):
+        """ POSTS: Gets all posts by user """
+        return requests.get('http://post_service:7082/api/' + category + '/posts/' + user_uuid).json()
+
+
 # Category (Post Service) Redirects
 
 @ns.route('/categories')
@@ -132,8 +139,16 @@ class PostItem(Resource):
         """ COMMENTS: Deletes a comment """
         return requests.delete('http://comment_service:7082/api/comments/' + comment_uuid).json()
 
-@ns.route('/comments/<string:post_uuid>')
+
+@ns.route('/comments/post/<string:post_uuid>')
 class PostComment(Resource):
     def get(self, post_uuid):
-        """ COMMENTS: Gets all comments for a post"""
-        return requests.get('http://comment_service:7082/api/comments/' + post_uuid).json()
+        """ COMMENTS: Gets all comments for a post """
+        return requests.get('http://comment_service:7082/api/comments/post/' + post_uuid).json()
+
+
+@ns.route('/comments/user/<string:user_uuid>')
+class UserComments(Resource):
+    def get(self, user_uuid):
+        """ COMMENTS: Gets all comments for a user """
+        return requests.get('http://comment_service:7082/api/comments/user/' + user_uuid).json()


### PR DESCRIPTION
These two routes are created for the profile page to obtain a user's posts and comments:
- '/api/all/posts/{user_uuid}'
- '/api/comments/user/{user_uuid}'

These routes return the comments and posts from most recent to latest

The following route was changed:
- '/api/comments/{post_uuid}' (Before)
- '/api/comments/post/{post_uuid}' (After)