### PR TITLE
implement post clear logic

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -67,6 +67,10 @@ export const uploadPost = async (
   return { type: "UPLOAD_POST", postUuid: post_uuid };
 };
 
+export const clearPosts = () => {
+  return { type: CLEAR_POSTS };
+};
+
 export const getPostByUuid = async (postUuid, userUuid) => {
   let response;
   // if user is null, i.e., not logged in, don't pass params

--- a/src/components/CategoryPage/index.jsx
+++ b/src/components/CategoryPage/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { getPostsByCategory, upvotePost } from "../../actions/posts";
+import { getPostsByCategory, upvotePost, clearPosts } from "../../actions/posts";
 import PostsList from "./PostsList";
 
 // custom hook (I'm trying it out lol)
@@ -33,6 +33,10 @@ const usePosts = () => {
     if (userLoaded) {
       getPosts();
     }
+
+    return () => {
+      dispatch(clearPosts());
+    };
   }, [userLoaded, user, getPostsByCategory, categoryName, location]);
 
   return [posts, error];


### PR DESCRIPTION
Fixes a bug where you click on a post from category page A, then navigate to category page B (category page B posts will be shown until the getPost API request finishes). Wrote a clearPost action to clear the posts after a component is unmounted.